### PR TITLE
Fix creation of new documents

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ function findOrCreatePlugin(schema, options) {
           callback(err, result, false)
         }
       } else {
-        for (var key in conditions) {
-         doc[key] = conditions[key]; 
+        for (var key in doc) {
+         conditions[key] = doc[key]; 
         }
-        var obj = new self(doc)
+        var obj = new self(conditions)
         obj.save(function(err) {
           callback(err, obj, true);
         });


### PR DESCRIPTION
When using nested schemas (e.g. {a:{id: ...}) and a condition part is nested, then the doc gets overwritten, e.g.

```
doc = { a: { b: 1, c: 2} }
condition = {a: {b: 1}}
```

results in `doc == condition`, because `doc[a]` gets replaced with `condition[a]`.

In `jamplify/supergoose` this was forked from, it was the different way round, conditions get extended by doc, so the loop is actually the wrong way around and the earlier commit to save the doc was only a partial fix.
