### PR TITLE
Never consider /$/ as valid value for saving

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ function findOrCreatePlugin(schema, options) {
         // If the value contain `$` remove the key value pair
         var keys = Object.keys(conditions);
 
-        keys.forEach(function (key) {
-          if (JSON.stringify(conditions[key]).indexOf('$') !== -1) {
+        for (var z = 0; z < keys.length; z++){
+          if (JSON.stringify(conditions[keys[z]]).indexOf('$') !== -1) {
             delete conditions[key];
           }
-        });
+        };
 
         var obj = new self(conditions)
         obj.save(function(err) {

--- a/index.js
+++ b/index.js
@@ -32,8 +32,16 @@ function findOrCreatePlugin(schema, options) {
         }
       } else {
         for (var key in doc) {
-         conditions[key] = doc[key]; 
+         conditions[key] = doc[key];
         }
+        // If the value contain `$` remove the key value pair
+        var keys = Object.keys(conditions);
+
+        keys.forEach((key) => {
+          if (JSON.stringify(conditions[key]).indexOf('$') !== -1) {
+            delete conditions[key];
+          }
+        });
         var obj = new self(conditions)
         obj.save(function(err) {
           callback(err, obj, true);

--- a/index.js
+++ b/index.js
@@ -37,11 +37,12 @@ function findOrCreatePlugin(schema, options) {
         // If the value contain `$` remove the key value pair
         var keys = Object.keys(conditions);
 
-        keys.forEach((key) => {
+        keys.forEach(function (key) {
           if (JSON.stringify(conditions[key]).indexOf('$') !== -1) {
             delete conditions[key];
           }
         });
+
         var obj = new self(conditions)
         obj.save(function(err) {
           callback(err, obj, true);


### PR DESCRIPTION
There was some case where all the argouments from the find query was used for creating a new doc in mongo (i got this bug while i was using `$exist : false` as find query and `findOrCreate` was treating it like an object, not like a statement, trying to save in the field the object and causing a validation error).
