### PR TITLE
fix '$' key value pair removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,13 @@ function findOrCreatePlugin(schema, options) {
         for (var key in doc) {
          conditions[key] = doc[key];
         }
+
         // If the value contain `$` remove the key value pair
         var keys = Object.keys(conditions);
 
         for (var z = 0; z < keys.length; z++){
           if (JSON.stringify(conditions[keys[z]]).indexOf('$') !== -1) {
-            delete conditions[key];
+            delete conditions[keys[z]];
           }
         };
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -16,7 +16,8 @@ mongoose.connection.on('error', function (err) {
 });
 
 var ClickSchema = new Schema({
-  ip : {type: String, required: true}
+  ip : {type: String, required: true},
+  hostname : {type: String, required: false}
 })
 
 ClickSchema.plugin(findOrCreate);
@@ -73,6 +74,24 @@ describe('findOrCreate', function() {
       click.should.be.an.Object;
       click.ip.should.eql('127.2.2.2');
       should.not.exist(click.subnet);
+      created.should.eql(true);
+      done();
+    })
+  })
+
+  it("should not add properties with a $ when creating an object different from the find call", function(done) {
+    Click.findOrCreate({
+      ip: '127.3.3.3',
+      subnet: { $exists: true }
+    }, {
+      ip: '127.3.3.3',
+      subnet: { $exists: true },
+      hostname: 'noplacelikehome'
+    }, function(err, click, created) {
+      click.should.be.an.Object;
+      click.ip.should.eql('127.3.3.3');
+      should.not.exist(click.subnet);
+      click.hostname.should.eql('noplacelikehome');
       created.should.eql(true);
       done();
     })


### PR DESCRIPTION
I ran into an issue when passing in two objects: one for the find call and another for creation, when the detected `$` attribute wasn't the last in the object's key value pairs. The error that I would receive was the following:
```
Uncaught TypeError: Cannot read property 'indexOf' of undefined
      at index.js:42:50
      at model.Query.<anonymous> (node_modules/mongoose/lib/model.js:3702:16)
      at node_modules/kareem/index.js:273:21
      at node_modules/kareem/index.js:127:16
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```
It appears the wrong key value pair is deleted from the object when a `$` is detected. The key that is removed is not from the current iterator, but rather from the last value of `key` when creating `conditions` from `doc` on lines 34-36. This will always be the last `key` in `doc`, which is a problem when the detected `$` key value pair is not the last `key` in `doc`.

I have added a test which should demonstrate this, as it will fail without the added correction. 

Please let me know if I can provide any additional clarifying details.