### PR TITLE
Return Promise when callback is not provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ Click.create({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
 });
 ```
 
+### Promise Support
+
+Choose your Promise library by setting
+[`Mongoose.Promise`](http://mongoosejs.com/docs/promises.html).
+
+The returned `Promise` shall resolve to an object with keys `doc` and
+`created` on success. It shall be rejected with `err` on failure.
+
+```javascript
+// Use environment-provided Promise (necessary to silence a Mongoose warning).
+mongoose.Promise = Promise;
+// To a findOrCreate().
+Click.findOrCreate({ip: '127.0.0.2'}).then(function (result) {
+  click = result.doc;
+  console.log('A click from', click.ip, ' using ', click.browser, ' was ', click.created ? 'created' : 'found');
+})
+```
+
 ## License 
 
 (The MIT License)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
 
 function findOrCreatePlugin(schema, options) {
   schema.statics.findOrCreate = function findOrCreate(conditions, doc, options, callback) {
+    var self = this;
+    var Promise = self.base.Promise.ES6;
     if (arguments.length < 4) {
       if (typeof options === 'function') {
         // Scenario: findOrCreate(conditions, doc, callback)
@@ -16,9 +18,22 @@ function findOrCreatePlugin(schema, options) {
         callback = doc;
         doc = {};
         options = {};
+      } else {
+        // Scenario: findOrCreate(conditions[, doc[, options]])
+        return new Promise(function(resolve, reject) {
+          self.findOrCreate(conditions, doc, options, function (ex, result, created) {
+            if (ex) {
+              reject(ex);
+            } else {
+              resolve({
+                doc: result,
+                created: created,
+              });
+            }
+          });
+        });
       }
     }
-    var self = this;
     this.findOne(conditions, function(err, result) {
       if(err || result) {
         if(options && options.upsert && !err) {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -96,4 +96,50 @@ describe('findOrCreate', function() {
       done();
     })
   })
+
+  it("should return a Promise when passed conditions", function() {
+    var ret = Click.findOrCreate({
+      ip: '127.4.4.4',
+    });
+    ret.should.be.a.Promise;
+    return ret.then(function(click) {
+      click.should.be.an.Object;
+      click.doc.should.be.an.Object;
+      click.doc.ip.should.eql('127.4.4.4');
+      click.created.should.eql(true);
+    })
+  })
+
+  it("should return a Promise when passed conditions, doc", function() {
+    var ret = Click.findOrCreate({
+      ip: '127.4.4.4',
+    }, {
+      ip: '127.5.5.5',
+    });
+    ret.should.be.a.Promise;
+    return ret.then(function(result) {
+      result.should.be.an.Object;
+      result.doc.should.be.an.Object;
+      result.doc.ip.should.eql('127.4.4.4');
+      result.created.should.eql(false);
+    })
+  })
+
+  it("should return a Promise when passed conditions, doc, options", function() {
+    var ret = Click.findOrCreate({
+      ip: '127.4.4.4',
+    }, {
+      ip: '127.5.5.5',
+    }, {
+      upsert: true,
+    });
+    ret.should.be.a.Promise;
+    return ret.then(function (result) {
+      result.should.be.an.Object;
+      // After an upsert, the object no longer matches, so expect
+      // null (that is a bug, right?):
+      should.equal(result.doc, null);
+      result.created.should.eql(false);
+    })
+  })
 })


### PR DESCRIPTION
Alternative to #4.

Modern Mongoose supports Promises or Thenables. This makes
it much easier to code against it. This plugin should
support Promises too.