### PR TITLE
Upsert conditions: fix post-upsert load when conditions no longer match

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function findOrCreatePlugin(schema, options) {
       if(err || result) {
         if(options && options.upsert && !err) {
           self.update(conditions, doc, function(err, count){
-            self.findOne(conditions, function(err, result) {
+            self.findById(result._id, function(err, result) {
               callback(err, result, false);
             });
           })

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -96,4 +96,37 @@ describe('findOrCreate', function() {
       done();
     })
   })
+
+  it("should support upsert", function(done) {
+    // Create something to upsert.
+    new Click({
+      ip: '128.0.0.0',
+    }).save(function (err, click) {
+      click.should.be.an.Object;
+      click.ip.should.eql('128.0.0.0');
+      should.equal(click.hostname, null);
+      // Upsert to add a hostname.
+      Click.findOrCreate({
+        ip: '128.0.0.0',
+      }, {
+        hostname: 'example.org',
+      }, {
+        upsert: true,
+      }, function (err, click, created) {
+        click.should.be.an.Object;
+        click.ip.should.eql('128.0.0.0');
+        click.hostname.should.eql('example.org');
+        created.should.eql(false);
+        // Verify that it actually was updated in the database.
+        Click.findOne({
+          ip: '128.0.0.0',
+        }, function (err, click) {
+          click.should.be.an.Object;
+          click.ip.should.eql('128.0.0.0');
+          click.hostname.should.eql('example.org');
+          done();
+        });
+      });
+    });
+  })
 })

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -129,4 +129,35 @@ describe('findOrCreate', function() {
       });
     });
   })
+
+  it("should return updated instance after upserting away from the condition", function(done) {
+    // Create something to upsert.
+    new Click({
+      ip: '128.1.1.1',
+    }).save(function(err, click) {
+      var _id = click._id;
+      click.should.be.an.Object;
+      click.ip.should.eql('128.1.1.1');
+      // Upsert in such a way that it no longer matches conditions.
+      Click.findOrCreate({
+        ip: '128.1.1.1',
+      }, {
+        ip: '128.1.1.2',
+      }, {
+        upsert: true,
+      }, function(err, click, created) {
+        // Should have returned upserted object even though it no
+        // longer matches the conditions.
+        click.should.be.an.Object
+        click.ip.should.eql('128.1.1.2');
+        created.should.eql(false);
+        // Verify that it actually was updated in the database.
+        Click.findById(_id, function (err, click) {
+          click.should.be.an.Object;
+          click.ip.should.eql('128.1.1.2');
+          done();
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
When using upsert, you might modify the entity so that it no longer matches the search conditions. The result is that the returned loaded object is `null` instead of the loaded object. This change fixes that by loading the updated entity using `_id` instead of `conditions`.