### PR TITLE
Fix bug in readme code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also include properties that aren't used in the
 find call, but will be added to the object if it is created.
 
 ```javascript
-Click.create({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
+Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
   Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Chrome'}, function(err, click) {
     console.log('A click from "%s" using "%s" was found', click.ip, click.browser);
     // prints A click from "127.0.0.1" using "Mozilla" was found


### PR DESCRIPTION
Hi there!
I was trying out this mongoose plugin some days ago and I figured one of the code samples in the README is not working as expected. This PR attempts to fixe the issue.

**The Issue:** 
There is this code sample in the README: 
```
Click.create({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
  Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Chrome'}, function(err, click) {
    console.log('A click from "%s" using "%s" was found', click.ip, click.browser);
    // prints A click from "127.0.0.1" using "Mozilla" was found
  })
});
```
When I run this locally, it prints: `A click from "127.0.0.1" using "undefined" was found`. I figured the first query inserts **two different** documents(`{ip: '127.0.0.1'}` and `{browser: 'Mozilla'}`) in the DB, while the second query does nothing since the document matching `{ip: '127.0.0.1'}` already exists. 

**The fix:**
I updated the code sample to use `Click.findOrCreate` for the first query:
```
Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Mozilla'}, function(err, val) {
  Click.findOrCreate({ip: '127.0.0.1'}, {browser: 'Chrome'}, function(err, click) {
    console.log('A click from "%s" using "%s" was found', click.ip, click.browser);
    // prints A click from "127.0.0.1" using "Mozilla" was found
  })
});
```
When I run this, it prints the expected message: `A click from "127.0.0.1" using "Mozilla" was found`. The first query inserts just a single document (merging the first and second argument), while the second query still does nothing since the document matching `{ip: '127.0.0.1'}` already exists. 