### PR TITLE
When removing query operators, only remove keys starting with dollar.

### DIFF
--- a/test/index_test.js
+++ b/test/index_test.js
@@ -68,6 +68,26 @@ describe('findOrCreate', function() {
     })
   })
 
+  it("should add values with a $ when creating the object", function(done) {
+    Click.findOrCreate({
+      ip: '$notAnInternetProtocolAddress'
+    }, function(err, click) {
+      click.ip.should.eql('$notAnInternetProtocolAddress');
+      done();
+    })
+  })
+
+  it("should add values with a $ when creating an object different from the find call", function(done) {
+    Click.findOrCreate({
+      ip: '$notIp'
+    }, {
+      ip: '$expected'
+    }, function(err, click) {
+      click.ip.should.eql('$expected');
+      done();
+    })
+  })
+
   it("should not add properties with a $ when creating the object", function(done) {
     Click.findOrCreate({
       ip: '127.2.2.2',


### PR DESCRIPTION
The changes introduced in #6 were intended to allow callers to do
things like the following:

```js
Model.findOrCreate({ key: '0', value: { $exists: false } })
```

However, its implementation prevented values contining the dollar sign
from being included.

This change preserves the behavior of removing query operators by
recursively finding any property starting with a dollar and removing
it. This allows values containing the dollar sign to be upserted while
still omiting query operators.

Fixes #30.